### PR TITLE
Reactive table redraws: use object, rather than name

### DIFF
--- a/.npm/package/npm-shrinkwrap.json
+++ b/.npm/package/npm-shrinkwrap.json
@@ -2,9 +2,13 @@
   "dependencies": {
     "datatables": {
       "version": "1.10.9",
+      "resolved": "https://registry.npmjs.org/datatables/-/datatables-1.10.9.tgz",
+      "from": "datatables@1.10.9",
       "dependencies": {
         "jquery": {
-          "version": "2.1.4"
+          "version": "2.1.4",
+          "resolved": "https://registry.npmjs.org/jquery/-/jquery-2.1.4.tgz",
+          "from": "jquery@2.1.4"
         }
       }
     }

--- a/client/tableInit.js
+++ b/client/tableInit.js
@@ -33,7 +33,7 @@ tableInit = function tableInit(tabularTable, template) {
           rowData = col.tmplContext(rowData);
         }
 
-        Blaze.renderWithData(tmpl, rowData, cell);
+        Blaze.renderWithData(tmpl, rowData, cell, undefined, template.view);
       };
 
       // Then delete the `tmpl` property since DataTables

--- a/client/tabular.js
+++ b/client/tabular.js
@@ -116,7 +116,7 @@ var tabularOnRendered = function () {
 
   // Reactively determine table columns, fields, and searchFields.
   // This will rerun whenever the current template data changes.
-  var lastTableName;
+  var lastTable;
   template.autorun(function () {
     var data = Template.currentData();
 
@@ -139,7 +139,7 @@ var tabularOnRendered = function () {
     // attribute. If we didn't change it, we can stop here,
     // but we need to reload the table if this is not the first
     // run
-    if (tabularTable.name === lastTableName) {
+    if (tabularTable === lastTable) {
       if (table) {
         // passing `false` as the second arg tells it to
         // reset the paging
@@ -150,15 +150,14 @@ var tabularOnRendered = function () {
 
     // If we reactively changed the `table` attribute, run
     // onUnload for the previous table
-    if (lastTableName !== undefined) {
-      var lastTableDef = Tabular.tablesByName[lastTableName];
-      if (lastTableDef && typeof lastTableDef.onUnload === 'function') {
-        lastTableDef.onUnload();
+    if (lastTable !== undefined) {
+      if (lastTable && typeof lastTable.onUnload === 'function') {
+        lastTable.onUnload();
       }
     }
 
-    // Cache this table name as the last table name for next run
-    lastTableName = tabularTable.name;
+    // Cache this table object for next run
+    lastTable = tabularTable;
 
     // Figure out and update the columns, fields, and searchFields
     tableInit(tabularTable, template);


### PR DESCRIPTION
When the tabular template data changes, we might be recreating a table
with the same name, but different attributes (typical example: i18n'd
column titles). In that case, we want to test object equality rather than
title equality when attempting to amortize the dataTable delete/recreate 
operations.

See § "With a forked version" of http://stackoverflow.com/a/35650141/435004 for the use case.
