### PR TITLE
Fix #405 - keep track of blaze views and destroy when refreshing

### DIFF
--- a/client/main.js
+++ b/client/main.js
@@ -69,7 +69,8 @@ Template.tabular.onRendered(function () {
   template.tabular.recordsTotal = 0;
   template.tabular.recordsFiltered = 0;
   template.tabular.isLoading = new ReactiveVar(true);
-
+  template.blazeViews = [];
+  
   // These are some DataTables options that we need for everything to work.
   // We add them to the options specified by the user.
   const ajaxOptions = {
@@ -440,6 +441,20 @@ Template.tabular.onRendered(function () {
     // Get data as array for DataTables to consume in the ajax function
     template.tabular.data = cursor.fetch();
 
+    //we're recreating the table here so before doing it, delete old views.
+    if (template.blazeViews) {
+      //console.log(`Removing ${template.blazeViews.length}`);
+      template.blazeViews.forEach(view => {
+        try {
+          Blaze.remove(view);
+        }
+        catch(err) {
+          console.error(err);
+        }
+      });
+      template.blazeViews = [];
+    }
+
     // For these types of reactive changes, we don't want to
     // reset the page we're on, so we pass `false` as second arg.
     // The exception is if we changed the results-per-page number,
@@ -479,6 +494,19 @@ Template.tabular.onDestroyed(function () {
       this.tabular.tableDef &&
       typeof this.tabular.tableDef.onUnload === 'function') {
     this.tabular.tableDef.onUnload();
+  }
+  //incase any are left over remove there here too
+  if (this.blazeViews) {
+    //console.log(`Removing ${this.blazeViews.length}`);
+    this.blazeViews.forEach(view => {
+      try {
+        Blaze.remove(view);
+      }
+      catch(err) {
+        console.error(err);
+      }
+    });
+    this.blazeViews = [];
   }
 
   // Destroy the DataTable instance to avoid memory leak

--- a/client/main.js
+++ b/client/main.js
@@ -69,7 +69,7 @@ Template.tabular.onRendered(function () {
   template.tabular.recordsTotal = 0;
   template.tabular.recordsFiltered = 0;
   template.tabular.isLoading = new ReactiveVar(true);
-  template.blazeViews = [];
+  template.tabular.blazeViews = [];
   
   // These are some DataTables options that we need for everything to work.
   // We add them to the options specified by the user.
@@ -441,10 +441,9 @@ Template.tabular.onRendered(function () {
     // Get data as array for DataTables to consume in the ajax function
     template.tabular.data = cursor.fetch();
 
-    //we're recreating the table here so before doing it, delete old views.
-    if (template.blazeViews) {
+    if (template.tabular.blazeViews) {
       //console.log(`Removing ${template.blazeViews.length}`);
-      template.blazeViews.forEach(view => {
+      template.tabular.blazeViews.forEach(view => {
         try {
           Blaze.remove(view);
         }
@@ -452,7 +451,7 @@ Template.tabular.onRendered(function () {
           console.error(err);
         }
       });
-      template.blazeViews = [];
+      template.tabular.blazeViews = [];
     }
 
     // For these types of reactive changes, we don't want to
@@ -495,10 +494,9 @@ Template.tabular.onDestroyed(function () {
       typeof this.tabular.tableDef.onUnload === 'function') {
     this.tabular.tableDef.onUnload();
   }
-  //incase any are left over remove there here too
-  if (this.blazeViews) {
+  if (this.tabular.blazeViews) {
     //console.log(`Removing ${this.blazeViews.length}`);
-    this.blazeViews.forEach(view => {
+    this.tabular.blazeViews.forEach(view => {
       try {
         Blaze.remove(view);
       }
@@ -506,7 +504,7 @@ Template.tabular.onDestroyed(function () {
         console.error(err);
       }
     });
-    this.blazeViews = [];
+    this.tabular.blazeViews = [];
   }
 
   // Destroy the DataTable instance to avoid memory leak

--- a/client/tableInit.js
+++ b/client/tableInit.js
@@ -16,7 +16,7 @@ function tableInit(tabularTable, template) {
   columns = columns.map(column => {
     let options = { ...column };
 
-    _.extend(options, templateColumnOptions(column));
+    _.extend(options, templateColumnOptions(template, column));
 
     // `templateColumnOptions` might have set defaultContent option. If not, we need it set
     // to something to protect against errors from null and undefined values.
@@ -59,7 +59,7 @@ function tableInit(tabularTable, template) {
 
 // The `tmpl` column option is special for this package. We parse it into other column options
 // and then remove it.
-function templateColumnOptions({ data, render, tmpl, tmplContext }) {
+function templateColumnOptions(template, { data, render, tmpl, tmplContext }) {
   if (!tmpl) return {};
 
   const options = {};
@@ -74,8 +74,10 @@ function templateColumnOptions({ data, render, tmpl, tmplContext }) {
     if (typeof tmplContext === 'function') {
       rowData = tmplContext(rowData);
     }
-
-    Blaze.renderWithData(tmpl, rowData, cell);
+    //this will be called by DT - let's keep track of all blazeviews it makes us create
+    let view = Blaze.renderWithData(tmpl, rowData, cell);
+    template.blazeViews.push(view);
+    return view;
   };
 
   // If we're displaying a template for this field and we've also provided data, we want to

--- a/client/tableInit.js
+++ b/client/tableInit.js
@@ -76,7 +76,7 @@ function templateColumnOptions(template, { data, render, tmpl, tmplContext }) {
     }
     //this will be called by DT - let's keep track of all blazeviews it makes us create
     let view = Blaze.renderWithData(tmpl, rowData, cell);
-    template.blazeViews.push(view);
+    template.tabular.blazeViews.push(view);
     return view;
   };
 


### PR DESCRIPTION
There are probably nicer ways of doing this but we needed to act quickly. This keeps track of the blaze views as they are created from the DT call and then before refreshing the table it will ask blaze to destroy them. This ensures none are left lingering.

I'm open to making any changes you require. 