### PR TITLE
Added a way to support a remove observer when _id is a string

### DIFF
--- a/package.js
+++ b/package.js
@@ -3,8 +3,8 @@
 Package.describe({
   name: 'aldeed:tabular',
   summary: 'Datatables for large or small datasets in Meteor',
-  version: '2.1.1',
-  git: 'https://github.com/aldeed/meteor-tabular.git'
+  version: '2.1.2',
+  git: 'https://github.com/Meteor-Community-Packages/meteor-tabular.git'
 });
 
 Npm.depends({

--- a/server/main.js
+++ b/server/main.js
@@ -170,7 +170,7 @@ Meteor.publish('tabular_getInfo', function (tableName, selector, sort, skip, lim
     removed: function (id) {
       //console.log('REMOVED');
       // _.findWhere is used to support Mongo ObjectIDs
-      filteredRecordIds = _.without(filteredRecordIds, _.findWhere(filteredRecordIds, id));
+      filteredRecordIds = typeof id === "string" ? filteredRecordIds = _.without(filteredRecordIds, id) : filteredRecordIds = _.without(filteredRecordIds, _.findWhere(filteredRecordIds, id));
       updateRecords();
     }
   });


### PR DESCRIPTION
In some cases, the observer of remove documents doesn't work when the `_id` of a document is a string. 

I used the solution proposed by [@zealzest](https://github.com/zealzest) in this comment https://github.com/Meteor-Community-Packages/meteor-tabular/pull/293#issuecomment-447275357