### PR TITLE
Fix to just project the exact fields are declared on columns and extraFields

### DIFF
--- a/client/tableInit.js
+++ b/client/tableInit.js
@@ -34,7 +34,7 @@ function tableInit(tabularTable, template) {
     // Build the list of field names we want included in the publication and in the searching
     const data = column.data;
     if (typeof data === 'string') {
-      fields[cleanFieldName(data)] = 1;
+      fields[data] = 1;
 
       // DataTables says default value for col.searchable is `true`,
       // so we will search on all columns that haven't been set to


### PR DESCRIPTION
Tabular has an amazing feature that is take care of the publications to just publish the fields are defined in columns and extraFields. 
But there was an issue when you have a document/object with sub-documents, because the code 
`fields[cleanFieldName(data)] = 1;`

execute `cleanFieldName` function to set what fields should be projected. When you have subdocuments and per example you set a column data with `parent.child`, `cleanFieldName` will get just the `parent`, then if you have a big document, all that fields will be published. This can be a security issue too.

I changed that line to doesn't clean the the field name, than unnecessary fields will be published. 
`fields[data] = 1;`

This simple change will save a lot of traffic but can have a little negative impact on systems that are using another subdocuments that are not explicit published. Anyway, I guess this is a important change. 
