### PR TITLE
Adding the property extraFieldWithSubDocument

### DIFF
--- a/README.md
+++ b/README.md
@@ -354,6 +354,61 @@ TabularTables.People = new Tabular.Table({
 });
 ```
 
+### Enabling Extra Fields for subdocuments
+
+When working with complex documents, you may need to include subdocuments in the extraFields configuration. To do this, you can simply specify the top-level field name of the subdocument.
+
+Document:
+```json
+{
+  'firstName': 'John',
+  'lastName': 'Doe',
+  'location': {
+    'address': '350 5th Ave',
+    'city': 'New York City',
+    'state': 'NY',
+    'zipCode': '10118'
+  }
+}
+```
+
+Example:
+
+```js
+TabularTables.People = new Tabular.Table({
+  // other properties...
+  extraFields: [
+    'firstName', 
+    'lastName',
+    'location'
+  ]
+});
+```
+In this example, the entire location subdocument will be included as an extra field.
+
+### Selective Field Inclusion with `extraFieldWithSubDocument`
+
+In cases where you do not need to publish the entire subdocument, you can selectively include specific fields using the `extraFieldWithSubDocument` property. This allows for more granular control over which parts of the subdocument are exposed.
+
+```js
+TabularTables.People = new Tabular.Table({
+  // other properties...
+  extraFieldWithSubDocument: true,
+  extraFields: [
+    'firstName', 
+    'lastName',
+    'location.state'
+  ]
+});
+```
+
+In this configuration, only the `state` field from the `location` subdocument will be published. Other fields under `location` will be excluded.
+
+> The default value of `extraFieldWithSubDocument` is `false`. If not explicitly enabled, the entire top-level subdocument will be included when specified in `extraFields`.
+
+> This feature is especially useful when you want to display **some fields from a subdocument in columns**, while including **other fields from the same subdocument** using `extraFields`.
+
+
 ## Modifying the Selector
 
 If your table requires the selector to be modified before it's published, you can modify it with the `changeSelector` method. This can be useful for modifying what will be returned in a search. It's called only on the server.

--- a/client/tableInit.js
+++ b/client/tableInit.js
@@ -34,7 +34,14 @@ function tableInit(tabularTable, template) {
     // Build the list of field names we want included in the publication and in the searching
     const data = column.data;
     if (typeof data === 'string') {
-      fields[cleanFieldName(data)] = 1;
+      
+      // When extraFields is defined and extraFieldWithSubDocument is true,
+      // we want to include the field as is, otherwise we clean it.
+      if (template.tabular.tableDef.extraFields && template.tabular.tableDef.extraFieldWithSubDocument) {
+        fields[data] = 1;
+      } else {
+        fields[cleanFieldName(data)] = 1;
+      }
 
       // DataTables says default value for col.searchable is `true`,
       // so we will search on all columns that haven't been set to

--- a/common/Tabular.js
+++ b/common/Tabular.js
@@ -46,6 +46,7 @@ Tabular.Table = class {
     this.skipCount = options.skipCount;
     this.searchCustom = options.searchCustom;
     this.searchExtraFields = options.searchExtraFields;
+    this.extraFieldWithSubDocument = typeof options.extraFieldWithSubDocument === 'boolean' ? options.extraFieldWithSubDocument : false;
 
     if (_.isArray(options.extraFields)) {
       const fields = {};
@@ -72,7 +73,8 @@ Tabular.Table = class {
       'alternativeCount',
       'skipCount',
       'name',
-      'selector'
+      'selector',
+      'extraFieldWithSubDocument'
     );
 
     Tabular.tablesByName[this.name] = this;

--- a/package.js
+++ b/package.js
@@ -3,7 +3,7 @@
 Package.describe({
   name: 'aldeed:tabular',
   summary: 'Datatables for large or small datasets in Meteor',
-  version: '3.0.0-rc.4',
+  version: '3.0.0-rc.5',
   git: 'https://github.com/Meteor-Community-Packages/meteor-tabular.git'
 });
 


### PR DESCRIPTION
This pull request introduces enhancements to the `aldeed:tabular` package, focusing on improved handling of subdocuments in the `extraFields` configuration, selective field inclusion, and updates to the package version. The most important changes include adding support for the `extraFieldWithSubDocument` property, modifying the field publication logic, and updating the package version.

### Enhancements to subdocument handling:

* **Documentation update**: Added explanations and examples for enabling subdocuments in `extraFields` and selectively including specific fields using the new `extraFieldWithSubDocument` property in the `README.md`.
* **New property**: Introduced the `extraFieldWithSubDocument` property in the `Tabular.Table` class to allow granular control over subdocument field inclusion. The property defaults to `false`. [[1]](diffhunk://#diff-f5e10c5827323c1d17e780576f2788a3ca1edb64d5d8b1403a601cea84ff39d5R49) [[2]](diffhunk://#diff-f5e10c5827323c1d17e780576f2788a3ca1edb64d5d8b1403a601cea84ff39d5L75-R77)

### Field publication logic:

* **Field inclusion logic**: Updated the `tableInit` function to handle `extraFieldWithSubDocument`. When enabled, fields are included as-is; otherwise, they are cleaned before publication.

### Package update:

* **Version bump**: Updated the package version from `3.0.0-rc.4` to `3.0.0-rc.5` in `package.js`.